### PR TITLE
fix: fixing rollback node selection and updating version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@constellation-network/metagraph-monitoring-service",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Constellation metagraph monitoring service",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/interfaces/services/ssh/ISshService.ts
+++ b/src/interfaces/services/ssh/ISshService.ts
@@ -8,6 +8,6 @@ export default interface ISshService {
   loggerService: ILoggerService;
 
   setConnection(): Promise<void>;
-  executeCommand(command: string): Promise<string>;
+  executeCommand(command: string, ignoreErrors?: boolean): Promise<string>;
   destroyConnection(): Promise<void>;
 }


### PR DESCRIPTION
### Changes
+ Fixing rollback node selection to select the node that contains the last snapshot hash returned from block explorer
+ If the node is forked, and previously we always selected the first node, we can choose the wrong node and then the rollback will traverse the snapshots until it finds the last calculated state that matches the last snapshot hash accepted by GL0. This PR solves the issue of selecting the right node to avoid unnecessary traverse

### Tests
It worked as expected
<img width="2063" alt="Screenshot 2024-08-16 at 12 51 01" src="https://github.com/user-attachments/assets/a6c64b21-684e-467f-bfd2-0f44766c2d71">
