### PR TITLE
feat: adding alert conditions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ To run this service, you must provide the necessary configuration in the file: `
 *   **`metagraph.id`**: The unique identifier for your metagraph.
 *   **`metagraph.name`**: The name of your metagraph.
 *   **`metagraph.version`**: The version of your metagraph.
-*   **`metagraph.default_restart_conditions`**: Specifies the conditions under which your metagraph should restart. These conditions are located in the directory: `src/jobs/restart/conditions`. 
+*   **`metagraph.default_restart_conditions`**: Specifies the conditions under which your metagraph should restart. These conditions are located in the directory: `src/monitor/restart/conditions`. 
     *   By default, there are two conditions:
         *   `SnapshotStopped`: Triggers if your metagraph stops producing snapshots.
         *   `UnhealthyNodes`: Triggers if your metagraph nodes become unhealthy.
+*   **`metagraph.default_alert_conditions`**: Specifies when your metagraph should trigger alerts. These conditions are defined in the directory: `src/monitor/alerts/conditions`. 
+    *   By default, there are two conditions:
+        *   `DiskSpaceLimit`: Alerts when the available disk space drops below the threshold set by `min_disk_space_percent`.
+        *   `OwnerWalletOutOfFunds`: Alerts when the metagraph owner’s wallet balance falls below the value defined by `min_owner_wallet_balance`.
 *   **`metagraph.layers`**: Details about your metagraph layers. Options include:
     *   **`ignore_layer`**: Set to `true` to disable a layer such as `currency-l1` or `data-l1`.
     *   **`ports`**: Lists public, p2p, and cli ports.
@@ -48,6 +52,8 @@ To run this service, you must provide the necessary configuration in the file: `
 *   **`network.name`**: The network your metagraph is part of, such as `integrationnet` or `mainnet`.  
 *   **`network.nodes`**: Information about the GL0s nodes.  
 *   **`check_healthy_interval_in_minutes`**: The interval, in minutes, at which the health check should run.
+*   **`min_disk_space_percent`**: The minimum disk space percentage required for the node to avoid triggering disk space alerts.
+*   **`min_owner_wallet_balance`**: The minimum wallet balance for the metagraph owner to avoid triggering low balance alerts.
 
 ## Interfaces
 
@@ -56,7 +62,11 @@ We offer a suite of interfaces that allow you to customize the restart flow for 
 *  **`IRestartCondition`**: Use this interface to add new restart conditions to your metagraph. We currently implement this interface with two conditions:
     *   **`SnapshotStopped`**: Activates if your metagraph stops producing snapshots.
     *   **`UnhealthyNodes`**: Activates if your metagraph nodes become unhealthy. 
-       
+
+*  **`IAlertCondition`**: Use this interface to add new alert conditions to your metagraph. We currently implement this interface with two conditions:
+    *   `DiskSpaceLimit`: Activates when the available disk space drops below the threshold set by `min_disk_space_percent`.
+    *   `OwnerWalletOutOfFunds`: Activates when the metagraph owner’s wallet balance falls below the value defined by `min_owner_wallet_balance`.
+
 *  **`IAlertService`**: This interface allows the addition of new alert services to your restart mechanism. By default, we offer two options:
     *   **`NoAlertsService`**: Use this if no external alert system is required.
     *   **`OpsgenieAlertService`**: An example service for alerting via Opsgenie.

--- a/default-alert-conditions.ts
+++ b/default-alert-conditions.ts
@@ -1,0 +1,6 @@
+import {
+  DiskSpaceLimit,
+  OwnerWalletOutOfFunds,
+} from './src/monitor/alert/conditions';
+
+export { DiskSpaceLimit, OwnerWalletOutOfFunds };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@constellation-network/metagraph-monitoring-service",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Constellation metagraph monitoring service",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -21,6 +21,10 @@
     "./default-restart-conditions": {
       "require": "./dist/default-restart-conditions.js",
       "import": "./dist/default-restart-conditions.mjs"
+    },
+    "./default-alert-conditions": {
+      "require": "./dist/default-alert-conditions.js",
+      "import": "./dist/default-alert-conditions.mjs"
     },
     "./restart-groups": {
       "require": "./dist/restart-groups.js",

--- a/src/interfaces/alert-conditions/IAlertCondition.ts
+++ b/src/interfaces/alert-conditions/IAlertCondition.ts
@@ -1,0 +1,22 @@
+import IAlertService from '@interfaces/services/alert/IAlertService';
+import ILoggerService from '@interfaces/services/logger/ILoggerService';
+import ISshService from '@interfaces/services/ssh/ISshService';
+import { Config } from 'src/MonitoringConfiguration';
+
+export type ShouldAlertInfo = {
+  shouldAlert: boolean;
+  message?: string;
+  alertName?: string;
+};
+
+export default interface IAlertCondition {
+  name: string;
+  config: Config;
+  sshServices: ISshService[];
+  loggerService: ILoggerService;
+  alertService: IAlertService;
+  alertPriority: 'P1' | 'P2' | 'P3' | 'P4' | 'P5';
+
+  shouldAlert(): Promise<ShouldAlertInfo>;
+  triggerAlert(message: string): Promise<void>;
+}

--- a/src/interfaces/services/alert/IAlertService.ts
+++ b/src/interfaces/services/alert/IAlertService.ts
@@ -2,7 +2,7 @@ import { Config } from 'src/MonitoringConfiguration';
 
 import ILoggerService from '../logger/ILoggerService';
 
-export type AlertType = 'RestartStarted' | 'RestartFailed';
+export type AlertType = 'RestartStarted' | 'RestartFailed' | 'Informative';
 
 export default interface IAlertService {
   loggerService: ILoggerService;
@@ -14,5 +14,10 @@ export default interface IAlertService {
     lastMetagraphSnapshotOrdinal?: number,
   ): Promise<void>;
   createRestartFailed(failedReason: string): Promise<void>;
-  closeAlert(alertType: AlertType): Promise<void>;
+  closeAlert(alertType: AlertType, alertName?: string): Promise<void>;
+  createInformativeAlert(
+    message: string,
+    alertName: string,
+    alertPriority: 'P1' | 'P2' | 'P3' | 'P4' | 'P5',
+  ): Promise<void>;
 }

--- a/src/interfaces/services/metagraph/IMetagraphService.ts
+++ b/src/interfaces/services/metagraph/IMetagraphService.ts
@@ -19,6 +19,7 @@ export type MetagraphSnapshotInfo = {
   lastSnapshotTimestamp: number;
   lastSnapshotOrdinal: number;
   lastSnapshotHash: string;
+  ownerAddress: string;
 };
 
 export type MetagraphNodeInfo = {

--- a/src/monitor/alert/conditions/DiskSpaceLimit.ts
+++ b/src/monitor/alert/conditions/DiskSpaceLimit.ts
@@ -1,0 +1,110 @@
+import IAlertCondition, {
+  ShouldAlertInfo,
+} from '@interfaces/alert-conditions/IAlertCondition';
+import IAlertService from '@interfaces/services/alert/IAlertService';
+import ILoggerService from '@interfaces/services/logger/ILoggerService';
+import ISshService from '@interfaces/services/ssh/ISshService';
+import { Config, MonitoringConfiguration } from 'src/MonitoringConfiguration';
+
+export default class freeDiskSpacePercentLimit implements IAlertCondition {
+  name = 'freeDiskSpacePercentLimit';
+  config: Config;
+  sshServices: ISshService[];
+  loggerService: ILoggerService;
+  alertService: IAlertService;
+  alertPriority: 'P1' | 'P2' | 'P3' | 'P4' | 'P5';
+
+  constructor(monitoringConfiguration: MonitoringConfiguration) {
+    this.config = monitoringConfiguration.config;
+    this.sshServices = monitoringConfiguration.sshServices;
+    this.loggerService = monitoringConfiguration.loggerService;
+    this.alertService = monitoringConfiguration.alertService;
+    this.alertPriority = 'P3';
+  }
+
+  private customLogger(
+    message: string,
+    level: 'Info' | 'Warn' | 'Error' = 'Info',
+  ) {
+    const logMethods: Record<'Info' | 'Warn' | 'Error', (msg: string) => void> =
+      {
+        Info: this.loggerService.info.bind(this.loggerService),
+        Warn: this.loggerService.warn.bind(this.loggerService),
+        Error: this.loggerService.error.bind(this.loggerService),
+      };
+
+    logMethods[level](`[freeDiskSpacePercentLimit] ${message}`);
+  }
+
+  async shouldAlert(): Promise<ShouldAlertInfo> {
+    const minfreeDiskSpacePercentPercent = this.config.min_disk_space_percent;
+    if (!minfreeDiskSpacePercentPercent) {
+      this.customLogger(
+        `Minimal disk space percent not filled in config, ignoring`,
+      );
+      return {
+        shouldAlert: false,
+      };
+    }
+    try {
+      const instanceInformation = await Promise.all(
+        this.sshServices.map(async (sshService) => {
+          const freeDiskSpacePercentResponse = await sshService.executeCommand(
+            "df --output=used,size / | tail -n 1 | awk '{print 100 - ($1 / $2 * 100)}'",
+          );
+          const freeDiskSpacePercent = Number(freeDiskSpacePercentResponse);
+          return {
+            freeDiskSpacePercent,
+            ip: sshService.metagraphNode.ip,
+          };
+        }),
+      );
+
+      const instancesWithLowfreeDiskSpacePercent = instanceInformation.filter(
+        (info) => {
+          return info.freeDiskSpacePercent <= minfreeDiskSpacePercentPercent;
+        },
+      );
+
+      if (instancesWithLowfreeDiskSpacePercent.length === 0) {
+        this.customLogger('All instances with enough disk space');
+
+        await this.alertService.closeAlert('Informative', this.name);
+
+        return {
+          shouldAlert: false,
+        };
+      }
+
+      const message = instancesWithLowfreeDiskSpacePercent
+        .map(
+          (instance) =>
+            `IP: ${instance.ip}, Current Disk Space Percent: ${instance.freeDiskSpacePercent}%`,
+        )
+        .join('\n');
+
+      this.customLogger(
+        `Condition freeDiskSpacePercentLimit detected, message: ${message}`,
+      );
+
+      return {
+        shouldAlert: true,
+        message,
+        alertName: this.name,
+      };
+    } catch (e) {
+      this.customLogger(`Error when checking node disk space: ${e}`, 'Error');
+      return {
+        shouldAlert: false,
+      };
+    }
+  }
+
+  async triggerAlert(message: string): Promise<void> {
+    await this.alertService.createInformativeAlert(
+      message,
+      this.name,
+      this.alertPriority,
+    );
+  }
+}

--- a/src/monitor/alert/conditions/OwnerWalletOutOfFunds.ts
+++ b/src/monitor/alert/conditions/OwnerWalletOutOfFunds.ts
@@ -1,0 +1,103 @@
+import axios from 'axios';
+
+import IAlertCondition, {
+  ShouldAlertInfo,
+} from '@interfaces/alert-conditions/IAlertCondition';
+import { IMetagraphService } from '@interfaces/index';
+import IAlertService from '@interfaces/services/alert/IAlertService';
+import ILoggerService from '@interfaces/services/logger/ILoggerService';
+import ISshService from '@interfaces/services/ssh/ISshService';
+import { Config, MonitoringConfiguration } from 'src/MonitoringConfiguration';
+
+export default class OwnerWalletOutOfFunds implements IAlertCondition {
+  name = 'OwnerWalletOutOfFunds';
+  config: Config;
+  sshServices: ISshService[];
+  loggerService: ILoggerService;
+  alertService: IAlertService;
+  metagraphService: IMetagraphService;
+  alertPriority: 'P1' | 'P2' | 'P3' | 'P4' | 'P5';
+  beUrl: string;
+
+  constructor(monitoringConfiguration: MonitoringConfiguration) {
+    this.config = monitoringConfiguration.config;
+    const { name } = monitoringConfiguration.config.network;
+    this.beUrl = `https://be-${name}.constellationnetwork.io`;
+    this.sshServices = monitoringConfiguration.sshServices;
+    this.loggerService = monitoringConfiguration.loggerService;
+    this.alertService = monitoringConfiguration.alertService;
+    this.metagraphService = monitoringConfiguration.metagraphService;
+    this.alertPriority = 'P3';
+  }
+
+  private customLogger(
+    message: string,
+    level: 'Info' | 'Warn' | 'Error' = 'Info',
+  ) {
+    const logMethods: Record<'Info' | 'Warn' | 'Error', (msg: string) => void> =
+      {
+        Info: this.loggerService.info.bind(this.loggerService),
+        Warn: this.loggerService.warn.bind(this.loggerService),
+        Error: this.loggerService.error.bind(this.loggerService),
+      };
+
+    logMethods[level](`[OwnerWalletOutOfFunds] ${message}`);
+  }
+
+  async shouldAlert(): Promise<ShouldAlertInfo> {
+    const minOwnerWalletBalance = this.config.min_owner_wallet_balance;
+    if (!minOwnerWalletBalance) {
+      this.customLogger(
+        `Minimal owner wallet balance not filled in config, ignoring`,
+      );
+      return {
+        shouldAlert: false,
+      };
+    }
+    try {
+      const { ownerAddress } = this.metagraphService.metagraphSnapshotInfo;
+      const ownerAddressBalanceApiResponse = await axios.get(
+        `${this.beUrl}/addresses/${ownerAddress}/balance`,
+      );
+
+      const ownerWalletBalance =
+        ownerAddressBalanceApiResponse.data.data.balance / 10e7;
+
+      if (ownerWalletBalance > minOwnerWalletBalance) {
+        this.customLogger('Owner wallet with enough balance');
+
+        await this.alertService.closeAlert('Informative', this.name);
+
+        return {
+          shouldAlert: false,
+        };
+      }
+
+      const message = `Metagraph ${this.config.metagraph.name} owner address with low balance: ${ownerWalletBalance}`;
+
+      this.customLogger(message, 'Warn');
+
+      return {
+        shouldAlert: true,
+        message,
+        alertName: this.name,
+      };
+    } catch (e) {
+      this.customLogger(
+        `Error when checking owner wallet out of funds: ${e}`,
+        'Error',
+      );
+      return {
+        shouldAlert: false,
+      };
+    }
+  }
+
+  async triggerAlert(message: string): Promise<void> {
+    await this.alertService.createInformativeAlert(
+      message,
+      this.name,
+      this.alertPriority,
+    );
+  }
+}

--- a/src/monitor/alert/conditions/index.ts
+++ b/src/monitor/alert/conditions/index.ts
@@ -1,0 +1,4 @@
+import DiskSpaceLimit from './DiskSpaceLimit';
+import OwnerWalletOutOfFunds from './OwnerWalletOutOfFunds';
+
+export { DiskSpaceLimit, OwnerWalletOutOfFunds };

--- a/src/services/alert/NoAlertsService.ts
+++ b/src/services/alert/NoAlertsService.ts
@@ -26,4 +26,8 @@ export default class NoAlertsService implements IAlertService {
   async closeAlert(): Promise<void> {
     this.customLog(`No alerts`);
   }
+
+  async createInformativeAlert(): Promise<void> {
+    this.customLog(`No alerts`);
+  }
 }

--- a/src/services/metagraph/ConstellationMetagraphService.ts
+++ b/src/services/metagraph/ConstellationMetagraphService.ts
@@ -29,6 +29,7 @@ export default class ConstellationMetagraphService
       lastSnapshotTimestamp: 0,
       lastSnapshotOrdinal: 0,
       lastSnapshotHash: '',
+      ownerAddress: '',
     };
   }
 
@@ -43,6 +44,7 @@ export default class ConstellationMetagraphService
       const lastSnapshotTimestamp: number = response.data.data.timestamp;
       const lastSnapshotOrdinal: number = response.data.data.ordinal;
       const lastSnapshotHash: string = response.data.data.hash;
+      const ownerAddress: string = response.data.data.ownerAddress;
 
       this.customLogger(
         `LAST SNAPSHOT OF METAGRAPH ${this.metagraphId}: ${lastSnapshotTimestamp}. Ordinal: ${lastSnapshotOrdinal}. Hash: ${lastSnapshotHash}`,
@@ -52,6 +54,7 @@ export default class ConstellationMetagraphService
         lastSnapshotTimestamp,
         lastSnapshotOrdinal,
         lastSnapshotHash,
+        ownerAddress,
       };
     } catch (e) {
       throw Error(


### PR DESCRIPTION
### Changes
+ Added a new feature of informative alerts. Those alerts can be built by extending the interface IAlertCondition. Following the example of IRestartConditions, users can customize Alerts if they want to.
+ By default, we will have 2 alerts: `DiskSpaceLimit` and `OwnerWalletOutOfFunds`. 
+ The alerts above depend on 2 new parameters in the configuration: `minimal_disk_space_in_gib` and `minimal_owner_wallet_balance`
+ The alerts will monitor the nodes/owner wallet and then open alerts if the conditions are detected

### Tests
+ I've tested locally using DOR integrationnet metagraph as an example and it worked as expected